### PR TITLE
Disable Telegram Markdown parsing

### DIFF
--- a/hawkeye.py
+++ b/hawkeye.py
@@ -13,8 +13,8 @@ SYMBOL_BITGET = "BTCUSDT_UMCBL"
 TELEGRAM_TOKEN = "1234567890:ABCdefGhIJKlmNoPQrstUVwxyZ12345678"
 TELEGRAM_CHAT_ID = "123456789"
 
-# Telegram Bot init
-bot = telebot.TeleBot(TELEGRAM_TOKEN, parse_mode="Markdown")
+# Telegram Bot init (Markdown deaktiviert, um Sonderzeichen nicht zu parsen)
+bot = telebot.TeleBot(TELEGRAM_TOKEN, parse_mode=None)
 
 
 # === API Calls ===


### PR DESCRIPTION
## Summary
- turn off Telegram Markdown parsing to prevent underscores from breaking messages

## Testing
- `python -m py_compile hawkeye.py`


------
https://chatgpt.com/codex/tasks/task_e_68a49c22a43c8322bb644494b16a5895