### PR TITLE
Add menu and notification controls

### DIFF
--- a/hawkeye.py
+++ b/hawkeye.py
@@ -14,6 +14,7 @@ stop_loss = 42000.0
 take_profit = 46000.0
 
 bot = telebot.TeleBot(TELEGRAM_TOKEN)
+notifications_enabled = True
 
 # === FUNKTION: Kurs holen ===
 def get_price(sym):
@@ -26,9 +27,9 @@ def get_price(sym):
 
 # === FUNKTION: Kurs prüfen ===
 def check_price():
-    global symbol, stop_loss, take_profit
+    global symbol, stop_loss, take_profit, notifications_enabled
     price = get_price(symbol)
-    if price:
+    if price and notifications_enabled:
         if price <= stop_loss:
             bot.send_message(CHAT_ID, f"⚠ Stop-Loss erreicht bei {price} ({symbol})")
         elif price >= take_profit:
@@ -77,6 +78,42 @@ def set_config(message):
         f"Stop-Loss: {stop_loss}\n"
         f"Take-Profit: {take_profit}",
     )
+
+
+@bot.message_handler(commands=['menu', 'help'])
+def show_menu(message):
+    """Display available commands and current configuration."""
+    global symbol, stop_loss, take_profit, notifications_enabled
+    status = "an" if notifications_enabled else "aus"
+    bot.reply_to(
+        message,
+        "📋 Menü:\n"
+        "/set SYMBOL STOP_LOSS TAKE_PROFIT - Konfiguration setzen\n"
+        "/stop - Benachrichtigungen deaktivieren\n"
+        "/start - Benachrichtigungen aktivieren\n"
+        "/menu - Dieses Menü anzeigen\n\n"
+        f"Aktuelle Konfiguration:\n"
+        f"Symbol: {symbol}\n"
+        f"Stop-Loss: {stop_loss}\n"
+        f"Take-Profit: {take_profit}\n"
+        f"Benachrichtigungen: {status}",
+    )
+
+
+@bot.message_handler(commands=['stop'])
+def stop_notifications(message):
+    """Disable price alert notifications."""
+    global notifications_enabled
+    notifications_enabled = False
+    bot.reply_to(message, "🔕 Benachrichtigungen deaktiviert. Tippe /start zum Aktivieren.")
+
+
+@bot.message_handler(commands=['start'])
+def start_notifications(message):
+    """Enable price alert notifications and show menu."""
+    global notifications_enabled
+    notifications_enabled = True
+    bot.reply_to(message, "🔔 Benachrichtigungen aktiviert. Tippe /menu für Hilfe.")
 
 # === JOB LOOP ===
 schedule.every(5).minutes.do(check_price)


### PR DESCRIPTION
## Summary
- add menu command with configuration overview
- allow enabling/disabling notifications via /stop and /start commands
- send price alerts only when notifications are active

## Testing
- `python -m py_compile hawkeye.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4b5227d088322b428e1e2870298b3