### PR TITLE
Support multiple symbols per user

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hawkeye Telegram Bot
 
-Hawkeye ist ein einfacher Telegram-Bot, der Kryptowährungspreise überwacht und dich per Nachricht informiert, wenn dein Stop-Loss oder Take-Profit erreicht wird. Der Preis wird in regelmäßigen Abständen über die Binance Futures API abgefragt.
+Hawkeye ist ein einfacher Telegram-Bot, der Kryptowährungspreise überwacht und dich per Nachricht informiert, wenn dein Stop-Loss oder Take-Profit erreicht wird. Jeder Benutzer kann mehrere Symbole gleichzeitig beobachten. Der Preis wird in regelmäßigen Abständen über die Binance Futures API abgefragt.
 
 ## Voraussetzungen
 
@@ -29,7 +29,8 @@ python hawkeye.py
 
 Im Chat mit deinem Bot stehen folgende Befehle zur Verfügung:
 
-- `/set SYMBOL STOP_LOSS TAKE_PROFIT` – Konfiguration setzen, z. B. `/set BTCUSDT 42000 46000`
+- `/set SYMBOL STOP_LOSS TAKE_PROFIT` – Symbol hinzufügen oder aktualisieren, z. B. `/set BTCUSDT 42000 46000`
+- `/remove SYMBOL` – Symbol entfernen
 - `/stop` – Benachrichtigungen deaktivieren
 - `/start` – Benachrichtigungen aktivieren
 - `/menu` oder `/help` – Hilfe und aktuelle Einstellungen anzeigen


### PR DESCRIPTION
## Summary
- Allow each user to track multiple symbols with individual stop-loss and take-profit values
- Add `/remove` command and expand `/menu` to administer multiple symbols
- Document new multi-symbol capabilities and commands

## Testing
- `python -m py_compile hawkeye.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4c1f7daf48322902ced862641b4c2