### PR TITLE
Add percentage price alerts and command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Im Chat mit deinem Bot stehen folgende Befehle zur Verfügung:
 
 - `/set SYMBOL STOP_LOSS TAKE_PROFIT` – Symbol hinzufügen oder aktualisieren, z. B. `/set BTCUSDT 42000 46000`
 - `/remove SYMBOL` – Symbol entfernen
+- `/percent SYMBOL PROZENT` – Benachrichtigung bei ±PROZENT Preisänderung
 - `/stop` – Benachrichtigungen deaktivieren
 - `/start` – Benachrichtigungen aktivieren
 - `/menu` oder `/help` – Hilfe und aktuelle Einstellungen anzeigen


### PR DESCRIPTION
## Summary
- add `/percent` command to watch symbols for percentage price changes
- track base price and notify when change exceeds threshold
- show percent alerts in menu and document command

## Testing
- `python -m py_compile hawkeye.py`
- `pytest -q` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68a4d54302308322bd812675e40f36cc