### PR TITLE
Add command for immediate price query

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Im Chat mit deinem Bot stehen folgende Befehle zur Verfügung:
 - `/start` – Benachrichtigungen aktivieren
 - `/menu` oder `/help` – Hilfe und aktuelle Einstellungen anzeigen
 - `/interval MINUTEN` – Zeitabstand zwischen den Prüfungen festlegen
+- `/now` – Aktuelle Preise der beobachteten Symbole anzeigen
 
 ## Hinweise
 

--- a/hawkeye.py
+++ b/hawkeye.py
@@ -272,6 +272,23 @@ def set_interval_command(message):
     bot.reply_to(message, f"⏱ Prüfintervall auf {new_interval} Minuten gesetzt.")
 
 
+@bot.message_handler(commands=["now"])
+def show_current_prices(message):
+    cfg = get_user(message.chat.id)
+    symbols = cfg.get("symbols", {})
+    if not symbols:
+        bot.reply_to(message, "⚠ Keine Symbole konfiguriert.")
+        return
+    lines = ["📈 Aktuelle Preise:"]
+    for sym in symbols:
+        price = get_price(sym)
+        if price is None:
+            lines.append(f"{sym}: Preis nicht verfügbar")
+        else:
+            lines.append(f"{sym}: {price}")
+    bot.reply_to(message, "\n".join(lines))
+
+
 @bot.message_handler(commands=["menu", "help"])
 def show_menu(message):
     cfg = get_user(message.chat.id)


### PR DESCRIPTION
## Summary
- add `/now` command to query current prices of all tracked symbols
- document `/now` command in README

## Testing
- `python -m py_compile hawkeye.py`


------
https://chatgpt.com/codex/tasks/task_e_68a52e1e4f7c8322b29dad4e7a2ec28c