### PR TITLE
Fix sparkline parameter for top10 crypto charts

### DIFF
--- a/hawkeye.py
+++ b/hawkeye.py
@@ -133,7 +133,7 @@ def get_top10_cryptos():
                 "per_page": 10,
                 "page": 1,
                 "price_change_percentage": "24h",
-                "sparkline": True,
+                "sparkline": "true",
             },
             timeout=10,
         )


### PR DESCRIPTION
## Summary
- send CoinGecko `sparkline` param as lowercase string to render price lines

## Testing
- `pytest -q`
- `python -m py_compile hawkeye.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5db66a2648322a2c0918cc012b965