### PR TITLE
Include /top10 command in help menu

### DIFF
--- a/hawkeye.py
+++ b/hawkeye.py
@@ -369,6 +369,7 @@ def show_menu(message):
         "/start - Benachrichtigungen aktivieren",
         "/menu - Dieses Menü anzeigen",
         "/interval MINUTEN - Prüfintervall setzen",
+        "/top10 - Top 10 Kryptowährungen anzeigen",
         "",
         "Aktuelle Konfiguration:",
     ]


### PR DESCRIPTION
## Summary
- display Top 10 cryptocurrencies in the `/menu` help list

## Testing
- `python -m py_compile hawkeye.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5dc55deb8832299aa2afd60fd32df