### PR TITLE
Add CoinGecko API key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ pip install requests telebot schedule matplotlib mplfinance
 
 ## Konfiguration
 
-1. Kopiere die Datei `config.json` und trage deinen Bot-Token ein.
+1. Kopiere die Datei `config.json` und trage deinen Bot-Token ein. Optional kannst du
+   einen CoinGecko-API-Key (`coingecko_api_key`) hinzufügen, damit der `/top10`
+   Befehl zuverlässig Daten liefert.
 2. Starte den Bot anschließend mit:
 
 ```bash

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
   "telegram_token": "DEIN_TELEGRAM_TOKEN",
   "users": {},
-  "check_interval": 5
+  "check_interval": 5,
+  "coingecko_api_key": ""
 }


### PR DESCRIPTION
## Summary
- allow configuring a `coingecko_api_key` and include it in CoinGecko requests
- normalize 24h change field and handle missing data in `/top10`
- document optional CoinGecko API key in README

## Testing
- `python -m py_compile hawkeye.py`
- `pip install requests --quiet` *(fails: Cannot connect to proxy, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e18f0fc8832280e35148e7b93912