### PR TITLE
feat: add optional crypto data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,14 @@ pip install requests telebot schedule matplotlib mplfinance
 ## Konfiguration
 
 1. Kopiere die Datei `config.json` und trage deinen Bot-Token ein. Optional kannst du
-   einen CoinGecko-API-Key (`coingecko_api_key`) hinzufügen, damit der `/top10`
-   Befehl zuverlässig Daten liefert.
+   API-Schlüssel für verschiedene Datenquellen hinzufügen:
+   - `coingecko_api_key`
+   - `coinmarketcap_api_key`
+   - `coinpaprika_api_key`
+   - `cryptocompare_api_key`
+   Mit `api_provider` legst du fest, welche Quelle der `/top10`-Befehl nutzt
+   (`coingecko`, `coinmarketcap`, `coinpaprika`, `cryptocompare`). Wenn du keinen
+   Provider nutzen möchtest, lass das Feld leer oder wähle eine ungültige Option.
 2. Starte den Bot anschließend mit:
 
 ```bash

--- a/config.json
+++ b/config.json
@@ -2,5 +2,9 @@
   "telegram_token": "DEIN_TELEGRAM_TOKEN",
   "users": {},
   "check_interval": 5,
-  "coingecko_api_key": ""
+  "coingecko_api_key": "",
+  "coinmarketcap_api_key": "",
+  "coinpaprika_api_key": "",
+  "cryptocompare_api_key": "",
+  "api_provider": "coingecko"
 }


### PR DESCRIPTION
## Summary
- allow choosing CoinGecko, CoinMarketCap, CoinPaprika, or CryptoCompare for `/top10`
- only render top-10 charts when using CoinGecko
- document new `api_provider` and API key fields in config

## Testing
- `python -m py_compile hawkeye.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5e3ae75f08322afa9299c8fa1cca3