### PR TITLE
feat: add bitget provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pip install requests telebot schedule matplotlib mplfinance
    - `coinpaprika_api_key`
    - `cryptocompare_api_key`
    Mit `api_provider` legst du fest, welche Quelle der `/top10`-Befehl nutzt
-   (`coingecko`, `coinmarketcap`, `coinpaprika`, `cryptocompare`). Wenn du keinen
+   (`coingecko`, `coinmarketcap`, `coinpaprika`, `cryptocompare`, `bitget`). Wenn du keinen
    Provider nutzen möchtest, lass das Feld leer oder wähle eine ungültige Option.
 2. Starte den Bot anschließend mit:
 


### PR DESCRIPTION
## Summary
- support Bitget API for top10 list and candlestick charts
- document Bitget as selectable `api_provider`

## Testing
- `python -m py_compile hawkeye.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5ef3f548083229f8c5b75382f35f2