### PR TITLE
fix: use proper timestamp conversion for charts

### DIFF
--- a/hawkeye.py
+++ b/hawkeye.py
@@ -11,6 +11,7 @@ import io
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 from mplfinance.original_flavor import candlestick_ohlc
+from datetime import datetime
 
 # === KONFIGURATION ===
 BINANCE_PRICE_URL = "https://fapi.binance.com/fapi/v1/premiumIndex"
@@ -207,7 +208,7 @@ def generate_top10_chart(coins):
                     )
                     for t, o, h, l, c in raw:
                         ohlc_data.append(
-                            [mdates.epoch2num(t / 1000), o, h, l, c]
+                            [mdates.date2num(datetime.utcfromtimestamp(t / 1000)), o, h, l, c]
                         )
                     time.sleep(1)
                     break


### PR DESCRIPTION
## Summary
- add datetime import for timestamp conversions
- convert timestamps with `mdates.date2num(datetime.utcfromtimestamp(...))`

## Testing
- `python -m py_compile hawkeye.py`
- `python` *(stubbed dependencies to call `generate_top10_chart`)*

------
https://chatgpt.com/codex/tasks/task_e_68a62af84ba08322b15cc954971de1ad