### PR TITLE
Cache top10 candle data in SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Im Chat mit deinem Bot stehen folgende Befehle zur Verfügung:
 - `/interval MINUTEN` – Zeitabstand zwischen den Prüfungen festlegen
 - `/now` – Aktuelle Preise der beobachteten Symbole anzeigen
 - `/top10` – Top 10 Kryptowährungen mit Preis, 24h-Änderung und Candlestick-Chart
+  (Candlestick-Daten werden täglich in `cache.db` gespeichert; aktuelle Preise werden live geladen)
 
 ## Hinweise
 


### PR DESCRIPTION
## Summary
- cache daily OHLC data for top-10 markets in a new SQLite `cache.db`
- serve `/top10` command from cached candles while fetching live prices
- schedule daily refresh of cached data

## Testing
- `python -m py_compile hawkeye.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6818200c48322bda1a357d449ec3f