### PR TITLE
Add daily summary with configurable schedule

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
   "telegram_token": "DEIN_TELEGRAM_TOKEN",
   "users": {},
-  "check_interval": 5
+  "check_interval": 5,
+  "summary_time": "09:00"
 }

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -20,6 +20,7 @@
   "interval_set": "⏱ Prüfintervall auf {minutes} Minuten gesetzt.",
   "no_symbols": "⚠ Keine Symbole konfiguriert.",
   "current_prices_header": "📈 Aktuelle Preise:",
+  "daily_summary_header": "📊 Tageszusammenfassung:",
   "price_not_available": "{symbol}: Preis nicht verfügbar",
   "top10_load_error": "⚠ Top 10 konnten nicht geladen werden.",
   "top10_header": "🏆 Top 10 Kryptowährungen:",
@@ -57,4 +58,6 @@
   "language_usage": "⚠ Nutzung: /language CODE (z. B. en, de)",
   "language_set": "✅ Sprache auf {code} gesetzt.",
   "language_invalid": "⚠ Sprache {code} wird nicht unterstützt."
+  "usage_summarytime": "⚠ Nutzung: /summarytime HH:MM",
+  "summary_time_set": "🕒 Tageszusammenfassung um {time} eingestellt."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -20,6 +20,7 @@
   "interval_set": "⏱ Check interval set to {minutes} minutes.",
   "no_symbols": "⚠ No symbols configured.",
   "current_prices_header": "📈 Current prices:",
+  "daily_summary_header": "📊 Daily summary:",
   "price_not_available": "{symbol}: price not available",
   "top10_load_error": "⚠ Top 10 could not be loaded.",
   "top10_header": "🏆 Top 10 cryptocurrencies:",
@@ -57,4 +58,6 @@
   "language_usage": "⚠ Usage: /language CODE (e.g., en, de)",
   "language_set": "✅ Language set to {code}.",
   "language_invalid": "⚠ Language {code} not supported."
+  "usage_summarytime": "⚠ Usage: /summarytime HH:MM",
+  "summary_time_set": "🕒 Daily summary time set to {time}."
 }


### PR DESCRIPTION
## Summary
- add daily summary function to report price and 24h change
- enable /summary command and configurable /summarytime schedule
- schedule daily summary with `schedule.every().day.at(summary_time)`

## Testing
- `python -m py_compile hawkeye.py`

------
https://chatgpt.com/codex/tasks/task_e_68a7433187f88322abe7f60456779a89