### PR TITLE
Fix JSON formatting in translation files

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -57,7 +57,7 @@
   "bot_running": "🤖 Bot läuft...",
   "language_usage": "⚠ Nutzung: /language CODE (z. B. en, de)",
   "language_set": "✅ Sprache auf {code} gesetzt.",
-  "language_invalid": "⚠ Sprache {code} wird nicht unterstützt."
+  "language_invalid": "⚠ Sprache {code} wird nicht unterstützt.",
   "usage_summarytime": "⚠ Nutzung: /summarytime HH:MM",
   "summary_time_set": "🕒 Tageszusammenfassung um {time} eingestellt.",
   "usage_signal": "⚠ Nutzung: /signal SYMBOL BENCHMARK",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -57,7 +57,7 @@
   "bot_running": "🤖 Bot running...",
   "language_usage": "⚠ Usage: /language CODE (e.g., en, de)",
   "language_set": "✅ Language set to {code}.",
-  "language_invalid": "⚠ Language {code} not supported."
+  "language_invalid": "⚠ Language {code} not supported.",
   "usage_summarytime": "⚠ Usage: /summarytime HH:MM",
   "summary_time_set": "🕒 Daily summary time set to {time}.",
   "usage_signal": "⚠ Usage: /signal SYMBOL BENCHMARK",


### PR DESCRIPTION
## Summary
- Correct missing commas in English and German translation JSON files to avoid JSON decode errors

## Testing
- `python -m json.tool i18n/en.json`
- `python -m json.tool i18n/de.json`
- `pip install requests schedule matplotlib mplfinance pyTelegramBotAPI pandas` *(fails: Could not find a version that satisfies the requirement requests)*
- `python hawkeye.py` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68a7520177f0832286c5ef4fd940f68b