### PR TITLE
Ensure /top10 shows candlestick charts for all entries

### DIFF
--- a/hawkeye.py
+++ b/hawkeye.py
@@ -1012,6 +1012,8 @@ def show_top10(message):
             f"{i}. {coin.get('name')} ({symbol}): {price_str} USD ({change_str})"
         )
         chart = generate_cached_candle_chart(symbol)
+        if not chart:
+            chart = generate_binance_candlestick(symbol)
         if chart:
             bot.send_photo(message.chat.id, chart, caption=caption)
         else:


### PR DESCRIPTION
## Summary
- Fallback to live candlestick generation via Binance for /top10 entries missing cached data

## Testing
- `python -m py_compile hawkeye.py trading_strategy.py`


------
https://chatgpt.com/codex/tasks/task_e_68a756850a9c8322acc0fb3a1678cfc1