### PR TITLE
Remove default BTCUSDT for new users

### DIFF
--- a/hawkeye.py
+++ b/hawkeye.py
@@ -122,13 +122,7 @@ def get_user(chat_id):
     cid = str(chat_id)
     if cid not in users:
         users[cid] = {
-            "symbols": {
-                "BTCUSDT": {
-                    "stop_loss": 42000.0,
-                    "take_profit": 46000.0,
-                    "trailing_percent": None,
-                }
-            },
+            "symbols": {},
             "notifications": True,
             "language": "de",
         }


### PR DESCRIPTION
## Summary
- avoid setting `BTCUSDT` as a default symbol when a new user is created

## Testing
- `python -m py_compile hawkeye.py`


------
https://chatgpt.com/codex/tasks/task_e_68a75896c6bc8322b66b272d11f7e853