### PR TITLE
Add axis labels to history chart

### DIFF
--- a/hawkeye.py
+++ b/hawkeye.py
@@ -441,9 +441,10 @@ def generate_binance_candlestick(symbol):
             ax, ohlc, colorup="green", colordown="red", width=0.6 / 24
         )
         ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M"))
-        ax.set_xticks([])
-        ax.set_yticks([])
+        ax.set_xlabel("Time (UTC)")
+        ax.set_ylabel("Price")
         ax.set_title(symbol)
+        fig.tight_layout()
         buf = io.BytesIO()
         fig.savefig(buf, format="png")
         plt.close(fig)


### PR DESCRIPTION
## Summary
- Show time and price axes on Binance candlestick charts for /history command

## Testing
- `python -m py_compile hawkeye.py`


------
https://chatgpt.com/codex/tasks/task_e_68a75b047a048322b73786ff996bd0dc