### PR TITLE
Add user roles and restrict admin commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ pip install requests telebot schedule matplotlib mplfinance
 
 ## Konfiguration
 
-1. Kopiere die Datei `config.json` und trage deinen Bot-Token ein. Der `/top10`-Befehl nutzt
-   Daten von Coingecko.
+1. Kopiere die Datei `config.json` und trage deinen Bot-Token ein. In der
+   Sektion `users` können Chat-IDs mit Rollen versehen werden, z. B.
+   `"role": "admin"`, um globale Einstellungen ändern zu dürfen. Der
+   `/top10`-Befehl nutzt Daten von Coingecko.
 2. Starte den Bot anschließend mit:
 
 ```bash
@@ -36,8 +38,10 @@ Im Chat mit deinem Bot stehen folgende Befehle zur Verfügung:
 - `/stop` – Benachrichtigungen deaktivieren
 - `/start` – Benachrichtigungen aktivieren
 - `/menu` oder `/help` – Hilfe und aktuelle Einstellungen anzeigen
-- `/interval MINUTEN` – Zeitabstand zwischen den Prüfungen festlegen
+- `/interval MINUTEN` – Zeitabstand zwischen den Prüfungen festlegen (nur Admin)
+- `/summarytime HH:MM` – Zeitpunkt der Tageszusammenfassung setzen (nur Admin)
 - `/now` – Aktuelle Preise der beobachteten Symbole anzeigen
+- `/summary` – Tageszusammenfassung jetzt senden (nur Admin)
 - `/top10` – Top 10 Kryptowährungen mit Preis, 24h-Änderung und Candlestick-Chart
   (Candlestick-Daten werden täglich in `cache.db` gespeichert; aktuelle Preise werden live geladen)
 - `/signal SYMBOL BENCHMARK` – Berechnet Score und Signal für `SYMBOL` relativ zur `BENCHMARK`
@@ -48,7 +52,7 @@ Eine einfache Umsetzung eines regelbasierten Systems findet sich in `trading_str
 
 ## Hinweise
 
-- Die Preise werden standardmäßig alle 5 Minuten geprüft. Über `/interval` lässt sich dieser Wert anpassen.
+- Die Preise werden standardmäßig alle 5 Minuten geprüft. Über `/interval` (nur Admin) lässt sich dieser Wert anpassen.
 - Der Bot aktualisiert sich selbst, wenn neue Commits im Git-Repository vorhanden sind.
 
 ## Lizenz

--- a/config.json
+++ b/config.json
@@ -1,6 +1,10 @@
 {
   "telegram_token": "DEIN_TELEGRAM_TOKEN",
-  "users": {},
+  "users": {
+    "123456789": {
+      "role": "admin"
+    }
+  },
   "check_interval": 5,
   "summary_time": "09:00"
 }

--- a/hawkeye.py
+++ b/hawkeye.py
@@ -125,6 +125,7 @@ def get_user(chat_id):
             "symbols": {},
             "notifications": True,
             "language": "de",
+            "role": "user",
         }
         save_config()
     # Sicherstellen, dass ältere Konfigurationen migriert werden
@@ -141,7 +142,13 @@ def get_user(chat_id):
     for sym_cfg in users[cid].get("symbols", {}).values():
         sym_cfg.setdefault("trailing_percent", None)
     users[cid].setdefault("language", "de")
+    users[cid].setdefault("role", "user")
     return users[cid]
+
+
+def is_admin(chat_id):
+    """Check if the user has admin role."""
+    return get_user(chat_id).get("role") == "admin"
 
 
 def translate(chat_id, key, **kwargs):
@@ -923,6 +930,9 @@ def remove_symbol(message):
 
 @bot.message_handler(commands=["interval"])
 def set_interval_command(message):
+    if not is_admin(message.chat.id):
+        bot.reply_to(message, translate(message.chat.id, "admin_only"))
+        return
     parts = message.text.split()[1:]
     if len(parts) != 1:
         bot.reply_to(message, translate(message.chat.id, "usage_interval"))
@@ -945,6 +955,9 @@ def set_interval_command(message):
 
 @bot.message_handler(commands=["summarytime"])
 def set_summary_time_command(message):
+    if not is_admin(message.chat.id):
+        bot.reply_to(message, translate(message.chat.id, "admin_only"))
+        return
     parts = message.text.split()[1:]
     if len(parts) != 1:
         bot.reply_to(message, translate(message.chat.id, "usage_summarytime"))
@@ -983,6 +996,9 @@ def show_current_prices(message):
 
 @bot.message_handler(commands=["summary"])
 def summary_command(message):
+    if not is_admin(message.chat.id):
+        bot.reply_to(message, translate(message.chat.id, "admin_only"))
+        return
     send_daily_summary(message.chat.id)
 
 

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -36,10 +36,10 @@
   "menu_stop": "/stop - Benachrichtigungen deaktivieren",
   "menu_start": "/start - Benachrichtigungen aktivieren",
   "menu_menu": "/menu - Dieses Menü anzeigen",
-  "menu_interval": "/interval MINUTEN - Prüfintervall setzen",
-  "menu_summarytime": "/summarytime HH:MM - Zeitpunkt der Tageszusammenfassung setzen",
+  "menu_interval": "/interval MINUTEN - Prüfintervall setzen (nur Admin)",
+  "menu_summarytime": "/summarytime HH:MM - Zeitpunkt der Tageszusammenfassung setzen (nur Admin)",
   "menu_now": "/now - Aktuelle Preise anzeigen",
-  "menu_summary": "/summary - Tageszusammenfassung jetzt senden",
+  "menu_summary": "/summary - Tageszusammenfassung jetzt senden (nur Admin)",
   "menu_history": "/history SYMBOL - Preisverlauf als Chart",
   "menu_top10": "/top10 - Top 10 Kryptowährungen anzeigen",
   "menu_signal": "/signal SYMBOL [BENCHMARK] - Score & Signal relativ zu BENCHMARK",
@@ -72,5 +72,6 @@
   "signal_result": "📈 {symbol}: Score {score}, Signal {signal}",
   "signal_buy": "kaufen",
   "signal_sell": "verkaufen",
-  "signal_hold": "halten"
+  "signal_hold": "halten",
+  "admin_only": "⚠ Nur Admins dürfen diesen Befehl verwenden."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -36,10 +36,10 @@
   "menu_stop": "/stop - disable notifications",
   "menu_start": "/start - enable notifications",
   "menu_menu": "/menu - show this menu",
-  "menu_interval": "/interval MINUTES - set check interval",
-  "menu_summarytime": "/summarytime HH:MM - set daily summary time",
+  "menu_interval": "/interval MINUTES - set check interval (admin only)",
+  "menu_summarytime": "/summarytime HH:MM - set daily summary time (admin only)",
   "menu_now": "/now - show current prices",
-  "menu_summary": "/summary - send daily summary now",
+  "menu_summary": "/summary - send daily summary now (admin only)",
   "menu_history": "/history SYMBOL - show price history chart",
   "menu_top10": "/top10 - show top 10 cryptocurrencies",
   "menu_signal": "/signal SYMBOL [BENCHMARK] - score and signal vs. BENCHMARK",
@@ -72,5 +72,6 @@
   "signal_result": "📈 {symbol}: score {score}, signal {signal}",
   "signal_buy": "buy",
   "signal_sell": "sell",
-  "signal_hold": "hold"
+  "signal_hold": "hold",
+  "admin_only": "⚠ Admins only."
 }


### PR DESCRIPTION
## Summary
- add role support and `is_admin` helper
- restrict `/interval`, `/summarytime` and `/summary` to admins
- document roles and mark admin-only commands

## Testing
- `python -m py_compile hawkeye.py`
- `python -m json.tool config.json > /tmp/config_tmp.json`


------
https://chatgpt.com/codex/tasks/task_e_68a762fb0ce8832297e7cd990121b6e4