### PR TITLE
Add trend following strategy with configurable parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ pip install requests telebot schedule matplotlib mplfinance
    `"role": "admin"`, um globale Einstellungen ändern zu dürfen. Optional
    lässt sich mit `"max_symbols"` die maximale Anzahl an Symbolen pro Nutzer
    festlegen (Standard 5). Über den Schlüssel `strategy` wählst du die zu
-   verwendende Handelsstrategie (aktuell nur `momentum`).
+   verwendende Handelsstrategie (`momentum` oder `trend_following`).
+   Strategieabhängige Optionen kannst du in `strategy_params` angeben.
 2. Beispielkonfiguration:
 
    ```json
@@ -32,7 +33,12 @@ pip install requests telebot schedule matplotlib mplfinance
      "users": {"123456789": {"role": "admin"}},
      "check_interval": 5,
      "summary_time": "09:00",
-     "strategy": "momentum"
+     "strategy": "trend_following",
+     "strategy_params": {
+       "short_window": 20,
+       "long_window": 50,
+       "donchian_window": 20
+     }
    }
    ```
 3. Starte den Bot anschließend mit:
@@ -61,9 +67,10 @@ Im Chat mit deinem Bot stehen folgende Befehle zur Verfügung:
 
 ## Beispiel: Trading-Signale
 
-Die Logik für Handelssignale liegt im Paket `strategies`. Die Standard-
-Implementierung `MomentumStrategy` basiert auf Trends und Relativer Stärke.
-Sie lässt sich auch außerhalb des Bots verwenden:
+Die Logik für Handelssignale liegt im Paket `strategies`. Neben der
+Standard-Implementierung `MomentumStrategy` steht mit
+`TrendFollowingStrategy` eine weitere Strategie bereit. Beide lassen sich
+auch außerhalb des Bots verwenden:
 
 ```python
 from strategies import get_strategy
@@ -72,9 +79,9 @@ import pandas as pd
 asset = pd.read_csv("asset.csv", parse_dates=["Date"], index_col="Date")
 bench = pd.read_csv("benchmark.csv", parse_dates=["Date"], index_col="Date")
 
-strategy = get_strategy("momentum")
+strategy = get_strategy("trend_following", short_window=20, long_window=50)
 signals = strategy.generate_signals(asset, bench)
-print(signals[["Score", "Signal"]].tail())
+print(signals[["Signal"]].tail())
 ```
 
 ## Hinweise

--- a/config.json
+++ b/config.json
@@ -8,5 +8,10 @@
   },
   "check_interval": 5,
   "summary_time": "09:00",
-  "strategy": "momentum"
+  "strategy": "trend_following",
+  "strategy_params": {
+    "short_window": 20,
+    "long_window": 50,
+    "donchian_window": 20
+  }
 }

--- a/hawkeye.py
+++ b/hawkeye.py
@@ -41,11 +41,13 @@ def load_config():
             "check_interval": 5,
             "summary_time": "09:00",
             "strategy": "momentum",
+            "strategy_params": {},
         }
     with open(CONFIG_FILE, "r", encoding="utf-8") as f:
         data = json.load(f)
         data.pop("coingecko_api_key", None)
         data.setdefault("strategy", "momentum")
+        data.setdefault("strategy_params", {})
         return data
 
 
@@ -56,6 +58,7 @@ def save_config():
         "check_interval": check_interval,
         "summary_time": summary_time,
         "strategy": strategy_name,
+        "strategy_params": strategy_params,
     }
     # optionalen trailing_percent-Schlüssel entfernen, wenn nicht gesetzt
     for cfg in data["users"].values():
@@ -101,7 +104,8 @@ users = config.get("users", {})  # chat_id -> user data
 check_interval = config.get("check_interval", 5)
 summary_time = config.get("summary_time", "09:00")
 strategy_name = config.get("strategy", "momentum")
-strategy = get_strategy(strategy_name)
+strategy_params = config.get("strategy_params", {})
+strategy = get_strategy(strategy_name, **strategy_params)
 
 bot = telebot.TeleBot(TELEGRAM_TOKEN)
 

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -2,17 +2,26 @@
 
 from .base import Strategy
 from .momentum import MomentumStrategy
+from .trend_following import TrendFollowingStrategy
 
 STRATEGY_CLASSES = {
     "momentum": MomentumStrategy,
+    "trend_following": TrendFollowingStrategy,
 }
 
 
-def get_strategy(name: str) -> Strategy:
+def get_strategy(name: str, **params) -> Strategy:
     """Return an instance of the strategy specified by ``name``."""
     try:
-        return STRATEGY_CLASSES[name.lower()]()
+        cls = STRATEGY_CLASSES[name.lower()]
+        return cls(**params)
     except KeyError as exc:
         raise ValueError(f"Unknown strategy: {name}") from exc
 
-__all__ = ["Strategy", "MomentumStrategy", "get_strategy", "STRATEGY_CLASSES"]
+__all__ = [
+    "Strategy",
+    "MomentumStrategy",
+    "TrendFollowingStrategy",
+    "get_strategy",
+    "STRATEGY_CLASSES",
+]

--- a/strategies/trend_following.py
+++ b/strategies/trend_following.py
@@ -1,0 +1,61 @@
+"""Trend following strategy implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+import pandas as pd
+
+from .base import Strategy
+
+
+@dataclass
+class TrendParams:
+    """Parameters for the trend following strategy."""
+
+    short_window: int = 20
+    long_window: int = 50
+    donchian_window: int = 20
+
+
+class TrendFollowingStrategy(Strategy):
+    """Generate signals based on EMA crossovers and Donchian channel breakouts."""
+
+    def __init__(
+        self,
+        short_window: int = 20,
+        long_window: int = 50,
+        donchian_window: int = 20,
+    ) -> None:
+        self.params = TrendParams(short_window, long_window, donchian_window)
+
+    def generate_signals(self, df: pd.DataFrame, benchmark: pd.DataFrame) -> pd.DataFrame:  # noqa: D401
+        data = df.copy()
+
+        # Exponential moving averages
+        data["EMA_short"] = (
+            data["Close"].ewm(span=self.params.short_window, adjust=False).mean()
+        )
+        data["EMA_long"] = (
+            data["Close"].ewm(span=self.params.long_window, adjust=False).mean()
+        )
+        data["EMA_diff"] = data["EMA_short"] - data["EMA_long"]
+
+        # Donchian channel
+        data["Donchian_high"] = data["High"].rolling(self.params.donchian_window).max()
+        data["Donchian_low"] = data["Low"].rolling(self.params.donchian_window).min()
+
+        # Signals
+        crossover_buy = (data["EMA_diff"] > 0) & (data["EMA_diff"].shift(1) <= 0)
+        crossover_sell = (data["EMA_diff"] < 0) & (data["EMA_diff"].shift(1) >= 0)
+        breakout_buy = data["Close"] > data["Donchian_high"].shift(1)
+        breakout_sell = data["Close"] < data["Donchian_low"].shift(1)
+
+        conditions = [
+            crossover_buy | breakout_buy,
+            crossover_sell | breakout_sell,
+        ]
+        choices = ["buy", "sell"]
+        data["Signal"] = np.select(conditions, choices, default="hold")
+
+        return data


### PR DESCRIPTION
## Summary
- implement `TrendFollowingStrategy` based on EMA crossovers and Donchian breakouts
- register strategy in factory and allow passing parameters from config
- document usage and provide config example for strategy parameters

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a76bc02fec8322b71b293d271659df