### PR TITLE
Add arbitrage trading strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ pip install requests telebot schedule matplotlib mplfinance
    `"role": "admin"`, um globale Einstellungen ändern zu dürfen. Optional
    lässt sich mit `"max_symbols"` die maximale Anzahl an Symbolen pro Nutzer
    festlegen (Standard 5). Über den Schlüssel `strategy` wählst du die zu
-   verwendende Handelsstrategie (`momentum` oder `trend_following`).
-   Strategieabhängige Optionen kannst du in `strategy_params` angeben.
+   verwendende Handelsstrategie (`momentum`, `trend_following` oder
+   `arbitrage`). Strategieabhängige Optionen kannst du in
+   `strategy_params` angeben.
 2. Beispielkonfiguration:
 
    ```json
@@ -33,11 +34,10 @@ pip install requests telebot schedule matplotlib mplfinance
      "users": {"123456789": {"role": "admin"}},
      "check_interval": 5,
      "summary_time": "09:00",
-     "strategy": "trend_following",
+     "strategy": "arbitrage",
      "strategy_params": {
-       "short_window": 20,
-       "long_window": 50,
-       "donchian_window": 20
+       "symbol": "BTCUSDT",
+       "threshold": 0.01
      }
    }
    ```
@@ -84,10 +84,29 @@ signals = strategy.generate_signals(asset, bench)
 print(signals[["Signal"]].tail())
 ```
 
+### Arbitrage-Strategie
+
+Für eine einfache Arbitrage zwischen Binance und Coinbase kannst du die
+Strategie wie folgt konfigurieren:
+
+```json
+{
+  "strategy": "arbitrage",
+  "strategy_params": {"symbol": "BTCUSDT", "threshold": 0.01}
+}
+```
+
+Die Preise beider Börsen werden verglichen. Überschreitet der Spread den
+Schwellenwert, wird ein Kauf-/Verkaufs-Signal ausgegeben.
+
 ## Hinweise
 
 - Die Preise werden standardmäßig alle 5 Minuten geprüft. Über `/interval` (nur Admin) lässt sich dieser Wert anpassen.
 - Der Bot aktualisiert sich selbst, wenn neue Commits im Git-Repository vorhanden sind.
+- Für echte Trades auf den Börsen sind API-Schlüssel erforderlich. Die
+  Beispiel-Implementierung nutzt nur öffentliche Preisdaten.
+- Arbitrage birgt Risiken durch Gebühren, Latenzen und Slippage; ein
+  positiver Spread garantiert keinen Gewinn.
 
 ## Lizenz
 

--- a/config.json
+++ b/config.json
@@ -8,10 +8,9 @@
   },
   "check_interval": 5,
   "summary_time": "09:00",
-  "strategy": "trend_following",
+  "strategy": "arbitrage",
   "strategy_params": {
-    "short_window": 20,
-    "long_window": 50,
-    "donchian_window": 20
+    "symbol": "BTCUSDT",
+    "threshold": 0.01
   }
 }

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -3,10 +3,12 @@
 from .base import Strategy
 from .momentum import MomentumStrategy
 from .trend_following import TrendFollowingStrategy
+from .arbitrage import ArbitrageStrategy
 
 STRATEGY_CLASSES = {
     "momentum": MomentumStrategy,
     "trend_following": TrendFollowingStrategy,
+    "arbitrage": ArbitrageStrategy,
 }
 
 
@@ -22,6 +24,7 @@ __all__ = [
     "Strategy",
     "MomentumStrategy",
     "TrendFollowingStrategy",
+    "ArbitrageStrategy",
     "get_strategy",
     "STRATEGY_CLASSES",
 ]

--- a/strategies/arbitrage.py
+++ b/strategies/arbitrage.py
@@ -1,0 +1,68 @@
+"""Cross-exchange arbitrage strategy implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import pandas as pd
+import requests
+
+from .base import Strategy
+
+
+@dataclass
+class ArbitrageParams:
+    """Configuration for the arbitrage strategy."""
+
+    symbol: str = "BTCUSDT"
+    threshold: float = 0.01  # 1%
+
+
+class ArbitrageStrategy(Strategy):
+    """Fetch prices from multiple exchanges and emit arbitrage signals."""
+
+    def __init__(self, symbol: str = "BTCUSDT", threshold: float = 0.01) -> None:
+        self.params = ArbitrageParams(symbol, threshold)
+
+    def _binance_price(self) -> float:
+        url = "https://api.binance.com/api/v3/ticker/price"
+        resp = requests.get(url, params={"symbol": self.params.symbol}, timeout=10)
+        resp.raise_for_status()
+        return float(resp.json()["price"])
+
+    def _coinbase_price(self) -> float:
+        pair = self.params.symbol
+        pair = pair.replace("USDT", "USD")
+        if "-" not in pair:
+            pair = pair[:-3] + "-" + pair[-3:]
+        url = f"https://api.coinbase.com/v2/prices/{pair}/spot"
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        return float(resp.json()["data"]["amount"])
+
+    def generate_signals(
+        self, df: pd.DataFrame | None = None, benchmark: pd.DataFrame | None = None
+    ) -> pd.DataFrame:
+        """Return current prices and arbitrage signal."""
+
+        binance = self._binance_price()
+        coinbase = self._coinbase_price()
+
+        spread = abs(binance - coinbase) / min(binance, coinbase)
+        signal = "hold"
+        if spread > self.params.threshold:
+            if binance < coinbase:
+                signal = "buy_binance_sell_coinbase"
+            else:
+                signal = "buy_coinbase_sell_binance"
+
+        data = pd.DataFrame(
+            [
+                {
+                    "Binance": binance,
+                    "Coinbase": coinbase,
+                    "Spread": spread,
+                    "Signal": signal,
+                }
+            ]
+        )
+        return data


### PR DESCRIPTION
## Summary
- implement `ArbitrageStrategy` retrieving Binance and Coinbase prices and signalling on configurable spread
- wire arbitrage strategy into factory and sample config
- document API keys and arbitrage risk in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a76dedfd3c8322a43feade44526f19