### PR TITLE
Default neutral fundamental score in momentum strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ signals = strategy.generate_signals(asset, bench)
 print(signals[["Signal"]].tail())
 ```
 
+Fehlen Fundamentaldaten, setzt die Momentum-Strategie einen neutralen Wert
+von `0.5` an. Diese Annahme entspricht dem Hawkeye-Blueprint.
+
 ### Arbitrage-Strategie
 
 Für eine einfache Arbitrage zwischen Binance und Coinbase kannst du die

--- a/strategies/momentum.py
+++ b/strategies/momentum.py
@@ -118,8 +118,9 @@ def compute_score(row: pd.Series, weights: Scores) -> float:
 
     rs_score = weights.rel_strength if row["Rel_Strength"] > 0 else 0
 
-    # Fundamentals placeholder: 0 if not provided.
-    fund_score = weights.fundamentals * row.get("Fundamental", 0)
+    # Fundamentals placeholder: assume neutral 0.5 if not provided.
+    # This mirrors the Hawkeye blueprint's default assumption.
+    fund_score = weights.fundamentals * row.get("Fundamental", 0.5)
 
     return (trend_score + vol_score + rs_score + fund_score) * 100
 


### PR DESCRIPTION
## Summary
- Assume a neutral fundamental score of 0.5 in `compute_score`, aligning with the Hawkeye blueprint when no data is supplied.
- Document the neutral 0.5 fundamental assumption in the README.

## Testing
- `python -m py_compile strategies/momentum.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a77176501483228320e2780a7772a2