### PR TITLE
Add configurable stress threshold to momentum strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ import pandas as pd
 asset = pd.read_csv("asset.csv", parse_dates=["Date"], index_col="Date")
 bench = pd.read_csv("benchmark.csv", parse_dates=["Date"], index_col="Date")
 
-strategy = get_strategy("trend_following", short_window=20, long_window=50)
-signals = strategy.generate_signals(asset, bench)
+strategy = get_strategy("momentum")
+signals = strategy.generate_signals(asset, bench, stress_threshold=0.08)
 print(signals[["Signal"]].tail())
 ```
 

--- a/trading_strategy.py
+++ b/trading_strategy.py
@@ -17,12 +17,20 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Generate trading signals")
     parser.add_argument("data", help="CSV with asset OHLCV data")
     parser.add_argument("--benchmark", required=True, help="CSV with benchmark data")
+    parser.add_argument(
+        "--stress-threshold",
+        type=float,
+        default=0.08,
+        help="ATR ratio threshold to flag market stress (default: 0.08)",
+    )
     args = parser.parse_args()
 
     df = pd.read_csv(args.data, parse_dates=["Date"], index_col="Date")
     bench = pd.read_csv(args.benchmark, parse_dates=["Date"], index_col="Date")
 
-    signals = MomentumStrategy().generate_signals(df, bench)
+    signals = MomentumStrategy().generate_signals(
+        df, bench, stress_threshold=args.stress_threshold
+    )
     print(signals[["Score", "Signal"]].tail())
 
 


### PR DESCRIPTION
## Summary
- incorporate ATR_ratio with benchmark EMA to determine market regime
- make stress threshold configurable through `generate_signals`
- expose stress threshold in CLI example and documentation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7722148888322b9210c21f2a14757