### PR TITLE
Filter unused parameters in strategy factory

### DIFF
--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,5 +1,10 @@
 """Strategy package with factory for available strategies."""
 
+from __future__ import annotations
+
+import inspect
+import logging
+
 from .base import Strategy
 from .momentum import MomentumStrategy
 from .trend_following import TrendFollowingStrategy
@@ -10,13 +15,28 @@ STRATEGY_CLASSES = {
     "trend_following": TrendFollowingStrategy,
     "arbitrage": ArbitrageStrategy,
 }
+logger = logging.getLogger(__name__)
 
 
 def get_strategy(name: str, **params) -> Strategy:
     """Return an instance of the strategy specified by ``name``."""
     try:
         cls = STRATEGY_CLASSES[name.lower()]
-        return cls(**params)
+        signature = inspect.signature(cls.__init__)
+        valid_params = {
+            p.name
+            for p in signature.parameters.values()
+            if p.name != "self"
+        }
+        filtered_params = {k: v for k, v in params.items() if k in valid_params}
+        ignored = set(params) - set(filtered_params)
+        if ignored:
+            logger.warning(
+                "Ignoring unsupported parameters for %s: %s",
+                name,
+                ", ".join(sorted(ignored)),
+            )
+        return cls(**filtered_params)
     except KeyError as exc:
         raise ValueError(f"Unknown strategy: {name}") from exc
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Test configuration providing minimal stubs for optional dependencies."""
+
+import os
+import sys
+import types
+
+
+def _ensure_stub(name: str) -> types.ModuleType:
+    module = types.ModuleType(name)
+    sys.modules.setdefault(name, module)
+    return module
+
+
+# Provide very small stubs so that strategy modules can be imported without
+# Provide very small stubs so that strategy modules can be imported without
+# heavy third-party dependencies. These stubs are sufficient because the tests
+# only exercise object construction and never call functions that rely on these
+# libraries.
+
+# Ensure the repository root is on the import path for tests executed from the
+# ``tests`` directory.
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+pandas = _ensure_stub("pandas")
+setattr(pandas, "DataFrame", type("DataFrame", (), {}))
+setattr(pandas, "Series", type("Series", (), {}))
+
+_ensure_stub("numpy")
+_ensure_stub("requests")
+

--- a/tests/test_strategy_factory.py
+++ b/tests/test_strategy_factory.py
@@ -1,0 +1,23 @@
+"""Tests for the strategy factory."""
+
+from strategies import get_strategy, MomentumStrategy, TrendFollowingStrategy
+
+
+def test_get_strategy_ignores_extra_params_momentum():
+    """Extraneous parameters should be ignored without raising."""
+
+    strategy = get_strategy("momentum", weights=None, foo="bar")
+
+    assert isinstance(strategy, MomentumStrategy)
+    assert not hasattr(strategy, "foo")
+
+
+def test_get_strategy_ignores_extra_params_trend_following():
+    """Ensure extra params do not raise for trend following strategy."""
+
+    strategy = get_strategy("trend_following", long_window=60, extra=123)
+
+    assert isinstance(strategy, TrendFollowingStrategy)
+    assert strategy.params.long_window == 60
+    assert not hasattr(strategy, "extra")
+


### PR DESCRIPTION
## Summary
- inspect strategy constructors and pass only supported arguments
- warn about ignored arguments in `get_strategy`
- add unit tests ensuring extra parameters are filtered

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a77515cca8832283b09fea1210fa72