### PR TITLE
Notify users about signal changes for tracked symbols

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -74,5 +74,6 @@
   "signal_buy": "kaufen",
   "signal_sell": "verkaufen",
   "signal_hold": "halten",
+  "signal_changed": "🔔 {symbol}: Signal {old} → {new}",
   "admin_only": "⚠ Nur Admins dürfen diesen Befehl verwenden."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -74,5 +74,6 @@
   "signal_buy": "buy",
   "signal_sell": "sell",
   "signal_hold": "hold",
+  "signal_changed": "🔔 {symbol}: signal changed from {old} to {new}",
   "admin_only": "⚠ Admins only."
 }

--- a/tests/test_signal_notification.py
+++ b/tests/test_signal_notification.py
@@ -1,0 +1,110 @@
+import sys
+import types
+
+# Stub modules required by hawkeye
+class _StubBot:
+    def __init__(self, *args, **kwargs):
+        pass
+    def send_message(self, *args, **kwargs):
+        pass
+    def send_photo(self, *args, **kwargs):
+        pass
+    def message_handler(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+    def infinity_polling(self, *args, **kwargs):
+        pass
+
+_apihelper = types.SimpleNamespace(ApiException=Exception)
+sys.modules.setdefault("telebot", types.SimpleNamespace(TeleBot=_StubBot, apihelper=_apihelper))
+sys.modules.setdefault("telebot.apihelper", _apihelper)
+
+class _Job:
+    def __init__(self):
+        self.minutes = self
+        self.day = self
+    def do(self, *args, **kwargs):
+        return self
+    def at(self, *args, **kwargs):
+        return self
+
+def _every(*args, **kwargs):
+    return _Job()
+
+sys.modules.setdefault(
+    "schedule", types.SimpleNamespace(clear=lambda: None, every=_every, run_pending=lambda: None)
+)
+
+plt = types.SimpleNamespace()
+mdates = types.SimpleNamespace()
+sys.modules.setdefault("matplotlib", types.SimpleNamespace(pyplot=plt, dates=mdates))
+sys.modules.setdefault("matplotlib.pyplot", plt)
+sys.modules.setdefault("matplotlib.dates", mdates)
+_sys_mpf = types.SimpleNamespace(candlestick_ohlc=lambda *a, **k: None)
+sys.modules.setdefault("mplfinance", types.SimpleNamespace(original_flavor=_sys_mpf))
+sys.modules.setdefault("mplfinance.original_flavor", _sys_mpf)
+
+class _DummyThread:
+    def __init__(self, *args, **kwargs):
+        pass
+    def start(self):
+        pass
+
+sys.modules.setdefault("threading", types.SimpleNamespace(Thread=_DummyThread))
+
+import hawkeye
+
+
+def test_signal_change_triggers_notification(monkeypatch):
+    # Arrange: setup user with existing last signal
+    monkeypatch.setattr(hawkeye, "users", {
+        "1": {
+            "notifications": True,
+            "symbols": {"ETHUSDT": {"last_signal": "buy"}},
+        }
+    })
+
+    messages = []
+
+    class DummyBot:
+        def send_message(self, cid, text):
+            messages.append((cid, text))
+        def send_photo(self, cid, photo):
+            messages.append(("photo", cid))
+        def message_handler(self, *args, **kwargs):
+            def decorator(func):
+                return func
+            return decorator
+        def infinity_polling(self, *args, **kwargs):
+            pass
+
+    class DummySignals:
+        def __init__(self, signal):
+            self.signal = signal
+        class _ILoc:
+            def __init__(self, signal):
+                self.signal = signal
+            def __getitem__(self, idx):
+                return {"Signal": self.signal}
+        @property
+        def iloc(self):
+            return self._ILoc(self.signal)
+
+    monkeypatch.setattr(hawkeye, "bot", DummyBot())
+    monkeypatch.setattr(hawkeye, "get_price", lambda sym: 100.0)
+    monkeypatch.setattr(hawkeye, "get_daily_ohlcv", lambda sym, limit=400: object())
+    monkeypatch.setattr(
+        hawkeye.strategy,
+        "generate_signals",
+        lambda asset, bench: DummySignals("sell"),
+    )
+    monkeypatch.setattr(hawkeye, "save_config", lambda: None)
+
+    # Act
+    hawkeye.check_price()
+
+    # Assert: last signal updated and notification sent
+    assert hawkeye.users["1"]["symbols"]["ETHUSDT"]["last_signal"] == "sell"
+    assert len(messages) == 1
+    assert "ETHUSDT" in messages[0][1]


### PR DESCRIPTION
## Summary
- Send notification when a tracked symbol's trading signal changes
- Track last signal per symbol in user config
- Add i18n strings for signal change messages
- Add regression test for signal change notifications

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7792327108322ac6aff4206ef4117