### PR TITLE
Add configurable crypto data sources and improve Binance error handling

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,5 +12,6 @@
   "strategy_params": {
     "symbol": "BTCUSDT",
     "threshold": 0.01
-  }
+  },
+  "data_source": "binance"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,3 +28,81 @@ setattr(pandas, "Series", type("Series", (), {}))
 _ensure_stub("numpy")
 _ensure_stub("requests")
 
+telebot = _ensure_stub("telebot")
+
+
+class _StubBot:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def send_message(self, *args, **kwargs):
+        pass
+
+    def send_photo(self, *args, **kwargs):
+        pass
+
+    def message_handler(self, *args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    def infinity_polling(self, *args, **kwargs):
+        pass
+
+
+_apihelper = types.SimpleNamespace(ApiException=Exception)
+telebot.TeleBot = _StubBot
+telebot.apihelper = _apihelper
+sys.modules.setdefault("telebot.apihelper", _apihelper)
+
+schedule_mod = _ensure_stub("schedule")
+
+
+class _Job:
+    def __init__(self):
+        self.minutes = self
+        self.day = self
+
+    def do(self, *args, **kwargs):
+        return self
+
+    def at(self, *args, **kwargs):
+        return self
+
+
+def _every(*args, **kwargs):
+    return _Job()
+
+
+schedule_mod.clear = lambda: None
+schedule_mod.every = _every
+schedule_mod.run_pending = lambda: None
+
+matplotlib = _ensure_stub("matplotlib")
+plt = types.SimpleNamespace()
+mdates = types.SimpleNamespace()
+matplotlib.pyplot = plt
+matplotlib.dates = mdates
+sys.modules.setdefault("matplotlib.pyplot", plt)
+sys.modules.setdefault("matplotlib.dates", mdates)
+
+mplfinance = _ensure_stub("mplfinance")
+mplfinance.original_flavor = types.SimpleNamespace(
+    candlestick_ohlc=lambda *a, **k: None
+)
+sys.modules.setdefault("mplfinance.original_flavor", mplfinance.original_flavor)
+
+threading = _ensure_stub("threading")
+
+
+class _DummyThread:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def start(self):
+        pass
+
+
+threading.Thread = _DummyThread
+

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -1,0 +1,33 @@
+import types
+import hawkeye
+
+
+def test_get_daily_ohlcv_uses_coinbase(monkeypatch):
+    monkeypatch.setattr(hawkeye, "data_source", "coinbase")
+    called = {}
+    def fake_coinbase(sym, limit=400):
+        called["sym"] = sym
+        called["limit"] = limit
+        return "coinbase"
+    monkeypatch.setattr(hawkeye, "get_daily_ohlcv_coinbase", fake_coinbase)
+    result = hawkeye.get_daily_ohlcv("ETHUSD", limit=10)
+    assert result == "coinbase"
+    assert called == {"sym": "ETHUSD", "limit": 10}
+
+
+def test_get_daily_ohlcv_binance_handles_error(monkeypatch, caplog):
+    monkeypatch.setattr(hawkeye, "data_source", "binance")
+    class Resp:
+        status_code = 400
+        text = "invalid"
+        def json(self):
+            return {"msg": "Invalid symbol"}
+    monkeypatch.setattr(
+        hawkeye.requests, "get", lambda *a, **k: Resp(), raising=False
+    )
+    with caplog.at_level(hawkeye.logging.ERROR):
+        result = hawkeye.get_daily_ohlcv("BAD")
+    assert result is None
+    assert "Binance API error for BAD" in caplog.text
+    assert "Invalid symbol" in caplog.text
+    assert "Client Error" not in caplog.text


### PR DESCRIPTION
## Summary
- allow choosing OHLCV data source via new `data_source` config option
- add Coinbase OHLCV provider alongside Binance
- log friendly error message when Binance API returns an error
- test data source selection and Binance error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8258d308483229173dd3bd458e30b