### PR TITLE
Add command sections and partial menu display

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -44,7 +44,7 @@
   "menu_trail": "/trail SYMBOL PROZENT - Trailing Stop-Loss setzen/entfernen",
   "menu_stop": "/stop - Benachrichtigungen deaktivieren",
   "menu_start": "/start - Benachrichtigungen aktivieren",
-  "menu_menu": "/menu - Dieses Menü anzeigen",
+  "menu_menu": "/menu [ABSCHNITT] - dieses Menü oder nur ABSCHNITT anzeigen",
   "menu_interval": "/interval MINUTEN - Prüfintervall setzen (nur Admin)",
   "menu_summarytime": "/summarytime HH:MM - Zeitpunkt der Tageszusammenfassung setzen (nur Admin)",
   "menu_now": "/now - Aktuelle Preise anzeigen",
@@ -89,5 +89,9 @@
   "signal_sell": "verkaufen",
   "signal_hold": "halten",
   "signal_changed": "🔔 {symbol}: Signal {old} → {new}",
-  "admin_only": "⚠ Nur Admins dürfen diesen Befehl verwenden."
+  "admin_only": "⚠ Nur Admins dürfen diesen Befehl verwenden.",
+  "menu_section_symbol": "🔧 Symbolverwaltung:",
+  "menu_section_trading": "💹 Trading:",
+  "menu_section_system": "⚙️ System:",
+  "menu_section_invalid": "⚠ Unbekannter Abschnitt: {section}"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -44,7 +44,7 @@
   "menu_trail": "/trail SYMBOL PERCENT - set/remove trailing stop-loss",
   "menu_stop": "/stop - disable notifications",
   "menu_start": "/start - enable notifications",
-  "menu_menu": "/menu - show this menu",
+  "menu_menu": "/menu [SECTION] - show this menu or SECTION",
   "menu_interval": "/interval MINUTES - set check interval (admin only)",
   "menu_summarytime": "/summarytime HH:MM - set daily summary time (admin only)",
   "menu_now": "/now - show current prices",
@@ -89,5 +89,9 @@
   "signal_sell": "sell",
   "signal_hold": "hold",
   "signal_changed": "🔔 {symbol}: signal changed from {old} to {new}",
-  "admin_only": "⚠ Admins only."
+  "admin_only": "⚠ Admins only.",
+  "menu_section_symbol": "🔧 Symbol management:",
+  "menu_section_trading": "💹 Trading:",
+  "menu_section_system": "⚙️ System:",
+  "menu_section_invalid": "⚠ Unknown section: {section}"
 }


### PR DESCRIPTION
## Summary
- Group commands into Symbol management, Trading, and System sections
- Add i18n strings and option to show only one section with `/menu <section>`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a89f10b56c83229d3d02b8941c9619