### PR TITLE
Handle request errors in Binance client

### DIFF
--- a/tests/test_binance_client_errors.py
+++ b/tests/test_binance_client_errors.py
@@ -1,0 +1,26 @@
+import pytest
+import binance_client
+
+
+def test_order_timeout(monkeypatch):
+    client = binance_client.BinanceClient("k", "s")
+
+    def fake_post(*args, **kwargs):
+        raise binance_client.Timeout("timeout")
+
+    monkeypatch.setattr(binance_client.requests, "post", fake_post, raising=False)
+
+    with pytest.raises(binance_client.BinanceAPIError):
+        client.order("BTCUSDT", "BUY", 1.0)
+
+
+def test_balance_request_exception(monkeypatch):
+    client = binance_client.BinanceClient("k", "s")
+
+    def fake_get(*args, **kwargs):
+        raise binance_client.RequestException("boom")
+
+    monkeypatch.setattr(binance_client.requests, "get", fake_get, raising=False)
+
+    with pytest.raises(binance_client.BinanceAPIError):
+        client.balance()


### PR DESCRIPTION
## Summary
- add logging and custom exception to BinanceClient to handle network errors
- implement fallback RequestException/Timeout when requests is stubbed
- add tests simulating Timeout and RequestException

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c2d88f688322b51b8104ce96b6ee