### PR TITLE
Add backtesting module and bot command

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -1,0 +1,78 @@
+"""Backtesting utilities for Hawkeye strategies."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import logging
+from typing import Tuple
+
+import pandas as pd
+import requests
+
+from strategies import get_strategy
+
+logger = logging.getLogger(__name__)
+
+BINANCE_KLINES_URL = "https://api.binance.com/api/v3/klines"
+
+
+def fetch_candles(symbol: str, start: str, end: str, interval: str = "1d") -> pd.DataFrame:
+    """Fetch historical candlestick data from Binance."""
+    start_ms = int(datetime.fromisoformat(start).timestamp() * 1000)
+    end_ms = int(datetime.fromisoformat(end).timestamp() * 1000)
+    params = {
+        "symbol": symbol.upper(),
+        "interval": interval,
+        "startTime": start_ms,
+        "endTime": end_ms,
+    }
+    try:
+        resp = requests.get(BINANCE_KLINES_URL, params=params, timeout=10)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        logger.error("Failed to fetch candles for %s: %s", symbol, exc)
+        raise
+    data = resp.json()
+    rows = [
+        {
+            "Date": datetime.fromtimestamp(int(item[0]) / 1000),
+            "Open": float(item[1]),
+            "High": float(item[2]),
+            "Low": float(item[3]),
+            "Close": float(item[4]),
+            "Volume": float(item[5]),
+        }
+        for item in data
+    ]
+    df = pd.DataFrame(rows).set_index("Date")
+    return df
+
+
+def run_backtest(
+    symbol: str,
+    start: str,
+    end: str,
+    strategy_name: str = "momentum",
+    interval: str = "1d",
+    **strategy_params,
+) -> Tuple[float, float]:
+    """Run backtest for ``symbol`` and return ROI and drawdown."""
+    df = fetch_candles(symbol, start, end, interval)
+    if df.empty:
+        raise ValueError("No data returned from Binance")
+    benchmark = df  # simplistic benchmark
+    strategy = get_strategy(strategy_name, **strategy_params)
+    signals = strategy.generate_signals(df, benchmark)
+    signals["Return"] = signals["Close"].pct_change().fillna(0)
+    mapping = {"buy": 1, "sell": 0}
+    signals["Position"] = signals["Signal"].map(mapping).ffill().fillna(0)
+    signals["Strategy_Return"] = signals["Return"] * signals["Position"].shift().fillna(0)
+    signals["Equity"] = (1 + signals["Strategy_Return"]).cumprod()
+    roi = float(signals["Equity"].iloc[-1] - 1)
+    cummax = signals["Equity"].cummax()
+    drawdown = float(((cummax - signals["Equity"]) / cummax).max())
+    logger.info("%s backtest ROI %.2f%%, drawdown %.2f%%", symbol, roi * 100, drawdown * 100)
+    print(f"ROI: {roi:.2%}, Max Drawdown: {drawdown:.2%}")
+    return roi, drawdown
+
+__all__ = ["run_backtest", "fetch_candles"]

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,0 +1,41 @@
+import sys
+sys.modules.pop("numpy", None)
+sys.modules.pop("pandas", None)
+import pandas as pd
+import importlib
+
+import backtest
+importlib.reload(backtest)
+
+
+def test_run_backtest(monkeypatch):
+    # Prepare dummy OHLC data
+    from datetime import datetime, timedelta
+    dates = [datetime(2021, 1, 1) + timedelta(days=i) for i in range(5)]
+    df = pd.DataFrame(
+        {
+            "Open": [1, 2, 3, 2, 4],
+            "High": [1, 2, 3, 2, 4],
+            "Low": [1, 2, 3, 2, 4],
+            "Close": [1, 2, 3, 2, 4],
+            "Volume": [1, 1, 1, 1, 1],
+        },
+        index=dates,
+    )
+
+    def fake_fetch(symbol, start, end, interval="1d"):
+        return df
+
+    monkeypatch.setattr(backtest, "fetch_candles", fake_fetch)
+
+    class DummyStrategy:
+        def generate_signals(self, data, benchmark):
+            out = data.copy()
+            out["Signal"] = ["buy", "hold", "sell", "buy", "sell"]
+            return out
+
+    monkeypatch.setattr(backtest, "get_strategy", lambda name, **kw: DummyStrategy())
+
+    roi, drawdown = backtest.run_backtest("BTCUSDT", "2021-01-01", "2021-01-05")
+    assert round(roi, 2) == 5.0
+    assert drawdown == 0.0


### PR DESCRIPTION
## Summary
- add `backtest.py` to fetch historical candles and compute ROI/drawdown using strategies
- expose new `/backtest` Telegram command to run backtests via bot
- include unit test for backtest logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8e6208d2c8322b86ffda8a1898578