### PR TITLE
Add protective order support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ pip install requests telebot schedule matplotlib mplfinance
      "strategy_params": {
        "symbol": "BTCUSDT",
        "threshold": 0.01
-     }
+     },
+     "auto_stop": 0.0,
+     "auto_takeprofit": 0.0
    }
    ```
 3. Starte den Bot anschließend mit:

--- a/binance_client.py
+++ b/binance_client.py
@@ -70,6 +70,64 @@ class BinanceClient:
             logger.error("Binance order request error for %s: %s", symbol, exc)
             raise BinanceAPIError(str(exc)) from exc
 
+    def place_protective_order(
+        self, symbol: str, side: str, quantity: float, stop_price: float
+    ) -> dict:
+        """Place a stop or take-profit market order.
+
+        The order type is chosen based on ``stop_price`` relative to the
+        current market price. When ``stop_price`` would realize a profit
+        the order is sent as ``TAKE_PROFIT_MARKET``, otherwise as
+        ``STOP_MARKET``.
+        """
+
+        order_type = "STOP_MARKET"
+        try:
+            resp = requests.get(
+                f"{self.BASE_URL}/fapi/v1/ticker/price",
+                params={"symbol": symbol},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            price = float(resp.json().get("price", 0.0))
+            if side.upper() == "SELL" and stop_price > price:
+                order_type = "TAKE_PROFIT_MARKET"
+            elif side.upper() == "BUY" and stop_price < price:
+                order_type = "TAKE_PROFIT_MARKET"
+        except Exception:
+            # If fetching the current price fails, default to STOP_MARKET
+            pass
+
+        params = {
+            "symbol": symbol,
+            "side": side.upper(),
+            "type": order_type,
+            "quantity": quantity,
+            "stopPrice": stop_price,
+            "timestamp": int(time.time() * 1000),
+        }
+        signed = self._sign(params)
+        headers = {"X-MBX-APIKEY": self.api_key}
+        try:
+            response = requests.post(
+                f"{self.BASE_URL}/fapi/v1/order",
+                headers=headers,
+                params=signed,
+                timeout=10,
+            )
+            response.raise_for_status()
+            return response.json()
+        except Timeout as exc:  # pragma: no cover - network timeout
+            logger.error(
+                "Binance protective order request timed out for %s", symbol
+            )
+            raise BinanceAPIError("protective order request timed out") from exc
+        except RequestException as exc:  # pragma: no cover - network error
+            logger.error(
+                "Binance protective order request error for %s: %s", symbol, exc
+            )
+            raise BinanceAPIError(str(exc)) from exc
+
     def balance(self) -> float:
         """Return available USDT balance."""
         params = {"timestamp": int(time.time() * 1000)}

--- a/config.json
+++ b/config.json
@@ -15,5 +15,7 @@
   },
   "data_source": "binance",
   "binance_api_key": "",
-  "binance_api_secret": ""
+  "binance_api_secret": "",
+  "auto_stop": 0.0,
+  "auto_takeprofit": 0.0
 }

--- a/tests/test_protective_orders.py
+++ b/tests/test_protective_orders.py
@@ -1,0 +1,107 @@
+import binance_client
+import hawkeye
+
+
+def test_place_protective_order_types(monkeypatch):
+    client = binance_client.BinanceClient("k", "s")
+
+    def fake_get(url, params=None, timeout=10):
+        class R:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {"price": "100"}
+        return R()
+
+    calls = []
+    def fake_post(url, headers=None, params=None, timeout=10):
+        calls.append(params)
+        class R:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {}
+        return R()
+
+    monkeypatch.setattr(binance_client.requests, "get", fake_get, raising=False)
+    monkeypatch.setattr(binance_client.requests, "post", fake_post, raising=False)
+
+    client.place_protective_order("BTCUSDT", "SELL", 1.0, 99.0)
+    client.place_protective_order("BTCUSDT", "SELL", 1.0, 105.0)
+
+    assert calls[0]["type"] == "STOP_MARKET"
+    assert calls[1]["type"] == "TAKE_PROFIT_MARKET"
+
+
+def test_check_price_places_protective_orders(monkeypatch):
+    class DummyBot:
+        def send_message(self, *a, **k):
+            pass
+        def send_photo(self, *a, **k):
+            pass
+        def message_handler(self, *a, **k):
+            def decorator(func):
+                return func
+            return decorator
+        def infinity_polling(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(hawkeye, "bot", DummyBot())
+
+    hawkeye.users = {
+        "1": {
+            "notifications": True,
+            "binance_api_key": "k",
+            "binance_api_secret": "s",
+            "symbols": {"BTCUSDT": {"trade_amount": 100.0}},
+        }
+    }
+    hawkeye.binance_clients = {}
+    hawkeye.auto_stop = 1.0
+    hawkeye.auto_takeprofit = 2.0
+
+    class DummySignals:
+        def __init__(self, signal):
+            self.signal = signal
+        class _ILoc:
+            def __init__(self, signal):
+                self.signal = signal
+            def __getitem__(self, idx):
+                return {"Signal": self.signal}
+        @property
+        def iloc(self):
+            return self._ILoc(self.signal)
+
+    monkeypatch.setattr(hawkeye, "get_price", lambda sym: 100.0)
+    monkeypatch.setattr(hawkeye, "get_daily_ohlcv", lambda sym: object())
+    monkeypatch.setattr(hawkeye.strategy, "generate_signals", lambda asset, bench: DummySignals("buy"))
+    monkeypatch.setattr(hawkeye, "save_config", lambda: None)
+    monkeypatch.setattr(hawkeye, "translate", lambda cid, key, **kwargs: key)
+    monkeypatch.setattr(hawkeye, "generate_buy_sell_chart", lambda sym: None)
+
+    class DummyClient:
+        def __init__(self, api_key, api_secret):
+            self.api_key = api_key
+            self.api_secret = api_secret
+            self.orders = []
+            self.protective = []
+        def balance(self):
+            return 1000.0
+        def order(self, symbol, side, qty):
+            self.orders.append((symbol, side, qty))
+        def place_protective_order(self, symbol, side, qty, stop_price):
+            self.protective.append((symbol, side, qty, stop_price))
+
+    monkeypatch.setattr(hawkeye, "BinanceClient", DummyClient)
+
+    hawkeye.check_price()
+
+    client = hawkeye.binance_clients["1"]
+    assert client.orders == [("BTCUSDT", "BUY", 1.0)]
+    assert (
+        client.protective
+        == [
+            ("BTCUSDT", "SELL", 1.0, 99.0),
+            ("BTCUSDT", "SELL", 1.0, 102.0),
+        ]
+    )


### PR DESCRIPTION
## Summary
- implement BinanceClient.place_protective_order to create STOP_MARKET or TAKE_PROFIT_MARKET orders
- add auto_stop and auto_takeprofit config options and use them in check_price to place protective orders
- document new settings and cover logic with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8e76730b4832296d5df0a61a3c852