### PR TITLE
Normalize trading symbols with configurable default quote

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,2 @@
+[binance]
+default_quote = USDT

--- a/tests/test_normalize_symbol.py
+++ b/tests/test_normalize_symbol.py
@@ -1,0 +1,17 @@
+import hawkeye
+
+
+def test_normalize_symbol_adds_default(monkeypatch):
+    monkeypatch.setattr(hawkeye, "DEFAULT_QUOTE", "USDT")
+    assert hawkeye.normalize_symbol("btc") == "BTCUSDT"
+
+
+def test_normalize_symbol_handles_existing_quote(monkeypatch):
+    monkeypatch.setattr(hawkeye, "DEFAULT_QUOTE", "USDT")
+    assert hawkeye.normalize_symbol("ETHBUSD") == "ETHBUSD"
+
+
+def test_normalize_symbol_exceptions(monkeypatch):
+    monkeypatch.setattr(hawkeye, "DEFAULT_QUOTE", "USDT")
+    assert hawkeye.normalize_symbol("USDT") is None
+    assert hawkeye.normalize_symbol("BUSD") == "BUSDUSDT"


### PR DESCRIPTION
## Summary
- add configurable `DEFAULT_QUOTE` via env or config.ini
- introduce `normalize_symbol` and apply across Binance call sites
- log normalized symbols and cover with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa401c2e708322a2701680b968b251