### PR TITLE
Normalize backtest command symbol handling

### DIFF
--- a/hawkeye.py
+++ b/hawkeye.py
@@ -1667,20 +1667,27 @@ def backtest_command(message):
         bot.reply_to(message, translate(message.chat.id, "usage_backtest"))
         return
     symbol, start, end = parts[0].upper(), parts[1], parts[2]
+    pair = normalize_symbol(symbol)
+    if not pair:
+        logger.info("No Binance pair for %s", symbol)
+        bot.reply_to(
+            message, translate(message.chat.id, "backtest_error", symbol=symbol)
+        )
+        return
     try:
-        roi, drawdown = run_backtest(symbol, start, end)
+        roi, drawdown = run_backtest(pair, start, end)
         bot.reply_to(
             message,
             translate(
                 message.chat.id,
                 "backtest_result",
-                symbol=symbol,
+                symbol=pair,
                 roi=roi * 100,
                 drawdown=drawdown * 100,
             ),
         )
     except Exception as e:  # pragma: no cover - broad exception for user input
-        logger.error("backtest command error for %s: %s", symbol, e)
+        logger.error("backtest command error for %s: %s", pair, e)
         bot.reply_to(
             message, translate(message.chat.id, "backtest_error", symbol=symbol)
         )

--- a/tests/test_backtest_command.py
+++ b/tests/test_backtest_command.py
@@ -1,0 +1,46 @@
+import types
+
+import hawkeye
+
+
+def test_backtest_command_normalizes_symbol(monkeypatch):
+    messages = []
+
+    class DummyBot:
+        def reply_to(self, message, text):
+            messages.append(text)
+
+        def send_message(self, *args, **kwargs):
+            pass
+
+        def send_photo(self, *args, **kwargs):
+            pass
+
+        def message_handler(self, *args, **kwargs):
+            def decorator(func):
+                return func
+            return decorator
+
+        def infinity_polling(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(hawkeye, "bot", DummyBot())
+    monkeypatch.setattr(hawkeye, "translate", lambda cid, key, **kwargs: key)
+
+    called = {}
+
+    def fake_run_backtest(symbol, start, end):
+        called["symbol"] = symbol
+        return 0.1, 0.2
+
+    monkeypatch.setattr(hawkeye, "run_backtest", fake_run_backtest)
+
+    msg = types.SimpleNamespace(
+        text="/backtest doge 2021-01-01 2021-02-01",
+        chat=types.SimpleNamespace(id=1),
+    )
+
+    hawkeye.backtest_command(msg)
+
+    assert called["symbol"] == "DOGEUSDT"
+    assert "backtest_result" in messages


### PR DESCRIPTION
## Summary
- normalize symbols in /backtest command before querying Binance
- add regression test ensuring symbol normalization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa49770f8083228c4a32f2ff7a8d87