### PR TITLE
Validate backtest date inputs

### DIFF
--- a/hawkeye.py
+++ b/hawkeye.py
@@ -1667,6 +1667,12 @@ def backtest_command(message):
         bot.reply_to(message, translate(message.chat.id, "usage_backtest"))
         return
     symbol, start, end = parts[0].upper(), parts[1], parts[2]
+    try:
+        datetime.strptime(start, "%Y-%m-%d")
+        datetime.strptime(end, "%Y-%m-%d")
+    except ValueError:
+        bot.reply_to(message, translate(message.chat.id, "invalid_date"))
+        return
     pair = normalize_symbol(symbol)
     if not pair:
         logger.info("No Binance pair for %s", symbol)

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -42,6 +42,7 @@
   "usage_history": "⚠ Nutzung: /history SYMBOL",
   "history_error": "⚠ Chart für {symbol} konnte nicht erstellt werden.",
   "usage_backtest": "⚠ Nutzung: /backtest SYMBOL START ENDE",
+  "invalid_date": "⚠ Ungültiges Datum. Format YYYY-MM-DD verwenden.",
   "backtest_error": "⚠ Backtest für {symbol} fehlgeschlagen.",
   "backtest_result": "📈 {symbol}: ROI {roi:.2f}%, Maximaler Drawdown {drawdown:.2f}%",
   "menu_header": "📋 Menü:",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -42,6 +42,7 @@
   "usage_history": "⚠ Usage: /history SYMBOL",
   "history_error": "⚠ Chart for {symbol} could not be created.",
   "usage_backtest": "⚠ Usage: /backtest SYMBOL START END",
+  "invalid_date": "⚠ Invalid date. Use YYYY-MM-DD.",
   "backtest_error": "⚠ Backtest failed for {symbol}.",
   "backtest_result": "📈 {symbol}: ROI {roi:.2f}%, Max drawdown {drawdown:.2f}%",
   "menu_header": "📋 Menu:",

--- a/tests/test_backtest_command.py
+++ b/tests/test_backtest_command.py
@@ -44,3 +44,37 @@ def test_backtest_command_normalizes_symbol(monkeypatch):
 
     assert called["symbol"] == "DOGEUSDT"
     assert "backtest_result" in messages
+
+
+def test_backtest_command_invalid_date(monkeypatch):
+    messages = []
+
+    class DummyBot:
+        def reply_to(self, message, text):
+            messages.append(text)
+
+        def send_message(self, *args, **kwargs):
+            pass
+
+        def send_photo(self, *args, **kwargs):
+            pass
+
+        def message_handler(self, *args, **kwargs):
+            def decorator(func):
+                return func
+            return decorator
+
+        def infinity_polling(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(hawkeye, "bot", DummyBot())
+    monkeypatch.setattr(hawkeye, "translate", lambda cid, key, **kwargs: key)
+
+    msg = types.SimpleNamespace(
+        text="/backtest btc 20210101 2021-02-01",
+        chat=types.SimpleNamespace(id=1),
+    )
+
+    hawkeye.backtest_command(msg)
+
+    assert messages == ["invalid_date"]


### PR DESCRIPTION
## Summary
- validate start and end dates for `/backtest` using `datetime.strptime`
- add `invalid_date` translation strings
- test `/backtest` with invalid date

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab27b984288322a75fd3dfaf4ce180